### PR TITLE
ks01ltexx: Grant rmt_storage proper unix perms

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -1007,19 +1007,12 @@ service irsc_util /system/bin/irsc_util "/etc/sec_config"
 service rmt_storage /system/bin/rmt_storage
     class core
     user root
-    group root readproc
-    disabled
-
-on property:ro.boot.emmc=true
-    start rmt_storage
+    group system wakelock
 
 service rfs_access /system/bin/rfs_access
    class core
    user system
    group system net_raw
-
-on property:ro.boot.emmc=true
-    start rfs_access
 
 on property:ro.debuggable=1
     chmod 0666 /sys/class/mhl/swing
@@ -1027,7 +1020,7 @@ on property:ro.debuggable=1
 
 # QMUX must be in multiple groups to support external process connections
 service qmuxd /system/bin/qmuxd
-    class main
+    class core
     user radio
     group radio audio bluetooth gps qcom_diag log
 

--- a/sepolicy/rmt_storage.te
+++ b/sepolicy/rmt_storage.te
@@ -1,1 +1,0 @@
-allow rmt_storage self:capability dac_override;


### PR DESCRIPTION
Do not grant DAC override permission which would allow this daemon
unix permissions to everything.

avc: denied { dac_override } for pid=2664 comm="rmt_storage" capability=1 scontext=u:r:rmt_storage:s0 tcontext=u:r:rmt_storage:s0 tclass=capability permissive=0

Add wakelock group to access:
/sys/power/wake_lock
-rw-rw----  1 radio  wakelock 4096 2017-06-28 00:37 wake_unlock